### PR TITLE
HTTPS quick fix

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
@@ -23,13 +24,18 @@ namespace PikaNoteAPI
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
-                    webBuilder
+                    webBuilder = webBuilder
                         .ConfigureKestrel((context, options) =>
                         {
                             options.Limits.MaxRequestBodySize = 268435456;
-                        })
-                        .UseUrls($"http://note.cloud.localhost:{args[0]}", $"https://note.cloud.localhost:{int.Parse(args[0]) + 1}")
-                        .UseKestrel();
+                        });
+                        if (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development") {
+                            webBuilder = webBuilder.UseUrls($"http://note.cloud.localhost:{args[0]}", $"https://note.cloud.localhost:{int.Parse(args[0]) + 1}");
+                        } else 
+                        {
+                            webBuilder = webBuilder.UseUrls($"http://note.cloud.localhost:{args[0]}");
+                        }
+                    webBuilder.UseKestrel();
                 });
     }
 }

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,17 +1,7 @@
-﻿{
-  "$schema": "http://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:25701",
-      "sslPort": 44337
-    }
-  },
+{
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
-      "launchBrowser": false,
       "launchUrl": "weatherforecast",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -19,12 +9,20 @@
     },
     "PikaNoteAPI": {
       "commandName": "Project",
-      "launchBrowser": false,
       "launchUrl": "weatherforecast",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+        "ASPNETCORE_ENVIRONMENT": "Production"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    }
+  },
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:25701",
+      "sslPort": 44337
     }
   }
 }

--- a/Startup.cs
+++ b/Startup.cs
@@ -123,7 +123,7 @@ namespace PikaNoteAPI
 
             app.UseSwagger();
             app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "PikaNote API"));
-            app.UseHttpsRedirection();
+            //app.UseHttpsRedirection();
             app.UseAuthorization();
             app.UseMiddleware<NoteFileStorageSecurity>();
             app.UseEndpoints(endpoints =>


### PR DESCRIPTION
A quick fix: make API use HTTPS only on dev scenarios, cuz on production we dont want it for now (it is hidden behind Azure proxies)